### PR TITLE
fix[#18]: 차량 대여 에러 수정 및 회사 정보 불러오기 수정

### DIFF
--- a/src/api/companyApi.js
+++ b/src/api/companyApi.js
@@ -4,7 +4,7 @@ import { handleApiError } from './handleApiError';
 export const getCompanyInformation = async () => {
   try {
     const response = await apiClient.get('/company/me');
-    return response.data;
+    return response.data.data;
   } catch (error) {
     handleApiError(error);
   }
@@ -13,7 +13,7 @@ export const getCompanyInformation = async () => {
 export const updateCompany = async (formData) => {
   try {
     const response = await apiClient.patch('/company/me', formData);
-    return response.data;
+    return response.data.data;
   } catch (error) {
     handleApiError(error);
   }
@@ -22,7 +22,7 @@ export const updateCompany = async (formData) => {
 export const deleteCompany = async () => {
   try {
     const response = await apiClient.delete('/company/me');
-    return response.data;
+    return response.data.data;
   } catch (error) {
     handleApiError(error);
   }

--- a/src/api/sleepApi.js
+++ b/src/api/sleepApi.js
@@ -100,8 +100,32 @@ export const downloadSleepVideosZip = async (ids = []) => {
         responseType: 'blob',
       }
     );
+    const blob = response.data;
+    const contentDisposition = response.headers['content-disposition'];
+    const filenameMatch = contentDisposition?.match(/filename="(.+)"/);
+    const filename = filenameMatch ? filenameMatch[1] : 'sleepVideos.zip';
+
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(link.href);
+
     return response.data;
   } catch (error) {
-    handleApiError(error);
+    if (error) {
+      const status = error.response?.status;
+      if (status === 401) {
+        alert('인증 정보가 유효하지 않습니다.');
+      } else if (status === 404) {
+        alert('일부 영상이 존재하지 않아 다운로드할 수 없습니다.');
+      } else {
+        alert('일괄 다운로드 중 오류가 발생했습니다.');
+      }
+    } else {
+      alert('알 수 없는 오류가 발생했습니다.');
+    }
   }
 };

--- a/src/components/DrowsinessAccordionTable.jsx
+++ b/src/components/DrowsinessAccordionTable.jsx
@@ -2,8 +2,8 @@ import React, { useState } from 'react';
 import { Download } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import axios from 'axios';
 import BaseTable from './BaseTable';
+import { downloadSleepVideosZip } from '@/api/sleepApi';
 
 export default function DrowsinessAccordionTable({ data }) {
   const [expandedRow, setExpandedRow] = useState(null);
@@ -18,49 +18,9 @@ export default function DrowsinessAccordionTable({ data }) {
 
   const handleBulkDownload = async (ids) => {
     if (isDownloading) return;
-    if (!ids || ids.length === 0) {
-      alert('다운로드할 영상이 없습니다.');
-      return;
-    }
-
     try {
       setIsDownloading(true);
-      const response = await axios.post(
-        '/api/sleep/videos/download',
-        { ids },
-        {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem('auth_token')}`,
-          },
-          responseType: 'blob',
-        }
-      );
-
-      const blob = response.data;
-      const contentDisposition = response.headers['content-disposition'];
-      const filenameMatch = contentDisposition?.match(/filename="(.+)"/);
-      const filename = filenameMatch ? filenameMatch[1] : 'videos.zip';
-
-      const link = document.createElement('a');
-      link.href = URL.createObjectURL(blob);
-      link.download = filename;
-      document.body.appendChild(link);
-      link.click();
-      link.remove();
-      URL.revokeObjectURL(link.href);
-    } catch (error) {
-      if (axios.isAxiosError(error)) {
-        const status = error.response?.status;
-        if (status === 401) {
-          alert('인증 정보가 유효하지 않습니다.');
-        } else if (status === 404) {
-          alert('일부 영상이 존재하지 않아 다운로드할 수 없습니다.');
-        } else {
-          alert('일괄 다운로드 중 오류가 발생했습니다.');
-        }
-      } else {
-        alert('알 수 없는 오류가 발생했습니다.');
-      }
+      await downloadSleepVideosZip(ids);
     } finally {
       setIsDownloading(false);
     }

--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -17,9 +17,8 @@ export default function Layout() {
     }
     (async () => {
       try {
-        console.log('회사 정보 요청 시작');
         const result = await getCompanyInformation();
-        setCompanyName(result.companyName);
+        setCompanyName(result?.companyName);
       } catch (err) {
         console.error('회사 정보 불러오기 실패:', err.message);
         setCompanyName('');

--- a/src/utils/vehicleHandlers.js
+++ b/src/utils/vehicleHandlers.js
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import apiClient from '@/api/apiClient';
 import { setDriverIndex } from './driverUtils';
 import { saveDriverMapsToStorage } from './storageUtils';
 export async function handleRentVehicle(
@@ -8,7 +8,7 @@ export async function handleRentVehicle(
   deviceUidMapRef
 ) {
   try {
-    await axios.post(`/api/vehicles/${row.vehicleNumber}/rent`, null, {});
+    await apiClient.post(`/vehicles/${row.vehicleNumber}/rent`, null, {});
     setData((prev) =>
       prev.map((item) =>
         item.vehicleNumber === row.vehicleNumber
@@ -22,7 +22,7 @@ export async function handleRentVehicle(
       return [];
     }
 
-    const res = await axios.get(`/api/vehicles/${deviceUid}/drivers`);
+    const res = await apiClient.get(`/vehicles/${deviceUid}/drivers`);
     const driverList = res.data?.data || [];
     if (driverList.length) {
       setDriverIndex(
@@ -54,7 +54,7 @@ export async function handleReturnVehicle(
   driverIndexMapRef
 ) {
   try {
-    await axios.post(`/api/vehicles/${row.vehicleNumber}/return`);
+    await apiClient.post(`/vehicles/${row.vehicleNumber}/return`);
 
     setData((prev) =>
       prev.map((item) =>
@@ -63,7 +63,7 @@ export async function handleReturnVehicle(
           : item
       )
     );
-    const res = await axios.get(`/api/sleep`, {
+    const res = await apiClient.get(`/sleep`, {
       params: {
         pageSize: sleepLimit,
         pageIdx: sleepPage,


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#18 
> ex) #이슈번호, #이슈번호

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
리팩토링 작업 중 발생한 차량 대여 에러를 수정했습닌다.
회원 정보 수정 시 바로 헤더에 회사명이 반영되도록 수정했습니다.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 회사 정보 요청 시 데이터 처리 방식을 개선하여, 더 정확한 정보가 표시됩니다.
  - 회사 이름 표시 시 오류가 발생하지 않도록 안정성을 높였습니다.
  - 수면 비디오 일괄 다운로드 시 오류 상황에 따른 알림 메시지를 추가하여 사용자 경험을 향상시켰습니다.

- **리팩터링**
  - 차량 대여 및 반납 기능에서 API 호출 방식을 개선하여 코드의 일관성과 유지보수성을 향상시켰습니다.
  - 수면 비디오 다운로드 로직을 외부 API 호출 함수로 통합하여 코드 간소화 및 오류 처리 일원화 작업을 진행했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->