### PR TITLE
[Deploy] 배포 시 외부 접근 허용 (#21)

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -10,6 +10,9 @@ export default defineConfig(({ mode }) => {
   return {
     plugins: [react(), tailwindcss(), tsconfigPaths()],
     server: {
+      host: true,
+      allowedHosts: ['nosleepdrive.site'],
+      port: 5173,
       proxy: {
         '/api': {
           target: API_BASE_URL,


### PR DESCRIPTION
## #️⃣ 연관된 이슈

closed #21 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- vite.config.ts 수정
  - host: true
    다른 외부 ip에서의 접근 허용
  - port: 5173
    명시적 포트 설정
  - allowedHosts: ['nosleepdrive.site']
    도메인을 통한 접근 허용

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/129841a5-4372-4358-b466-944672844b09)


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 개발 서버가 모든 네트워크 인터페이스에서 접근 가능하도록 설정이 변경되었습니다.
  - 허용된 호스트가 `nosleepdrive.site`로 제한되었습니다.
  - 서버 포트가 5173번으로 지정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->