### PR TITLE
fix[#23]: 매핑 정보 불러오기 및 날짜 오류 수정

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,12 +28,12 @@ function App() {
       }}
     >
       <Routes>
-        <Route path="/" element={<Layout />}>
+        <Route path="/signup" element={<SignUp />} />
+        <Route element={<Layout />}>
           <Route index element={<WelcomePage />} />
           <Route path="dashboard" element={<Dashboard />} />
           <Route path="drowsiness/search" element={<DrowsinessSearch />} />
           <Route path="drowsiness/:id" element={<DrowsinessDetail />} />
-          <Route path="signup" element={<SignUp />} />
           <Route path="edit" element={<EditProfile />} />
           <Route path="vehicles" element={<VehicleManagement />} />
         </Route>

--- a/src/api/apiClient.js
+++ b/src/api/apiClient.js
@@ -8,7 +8,6 @@ const apiClient = axios.create({
 });
 apiClient.interceptors.request.use((config) => {
   const token = localStorage.getItem('auth_token');
-  //console.log(`Bearer ${token}`);
   const excludedEndpoints = ['/company/login', '/company/signup'];
   const isExcluded = excludedEndpoints.some((url) => config.url.includes(url));
   if (!isExcluded && token) {

--- a/src/pages/Dashboard/Dashboard.jsx
+++ b/src/pages/Dashboard/Dashboard.jsx
@@ -11,6 +11,7 @@ import { getRecentSleepData } from '@/api/dashboardApi';
 import { downloadSleepVideo } from '@/api/sleepApi';
 import useDriverIndexMap from '@/hooks/useDriverIndexMap';
 import { getDriverIndex } from '@/utils/driverUtils';
+import { getCompanyInformation } from '@/api/companyApi';
 import {
   getVehicleCount,
   getSleepTodayCount,
@@ -18,6 +19,8 @@ import {
 } from '@/api/dashboardApi';
 import { saveDriverMapsToStorage } from '@/utils/storageUtils';
 import DashboardSummary from './DashboardSummary';
+import { recoverMappingsIfEmpty } from '@/utils/mappingUtils';
+
 export default function Dashboard() {
   const [selectedVehicle, setSelectedVehicle] = useState(null);
   const [showEditModal, setShowEditModal] = useState(false);
@@ -31,6 +34,8 @@ export default function Dashboard() {
   });
   const { driverIndexMapRef, deviceUidMapRef } = useDriverIndexMap();
   useEffect(() => {
+    recoverMappingsIfEmpty(driverIndexMapRef, deviceUidMapRef);
+    getCompanyInformation();
     fetchRecentVehicles();
     fetchRecentSleep();
     fetchSummaryData();
@@ -115,7 +120,7 @@ export default function Dashboard() {
     {
       key: 'detectedTime',
       label: '감지 날짜',
-      render: (value) => new Date(value).toLocaleDateString(),
+      render: (value) => value?.slice(0, 10),
     },
     {
       key: 'download',

--- a/src/pages/DrowsinessSearch.jsx
+++ b/src/pages/DrowsinessSearch.jsx
@@ -33,7 +33,7 @@ export default function DrowsinessSearch() {
   const [vehicleNumber, setVehicleNumber] = useState('');
   const formatDateLocal = (date) => {
     if (!date) return undefined;
-    const offset = date.getTimezoneOffset(); // 분
+    const offset = date.getTimezoneOffset();
     const localDate = new Date(date.getTime() - offset * 60 * 1000);
     return localDate.toISOString().split('T')[0];
   };

--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -7,8 +7,9 @@ export default function Layout() {
   const location = useLocation();
   const isAuthPage =
     location.pathname === '/signup' || location.pathname === '/';
-  const [companyName, setCompanyName] = useState('');
-
+  const [companyName, setCompanyName] = useState(
+    localStorage.getItem('companyName') || '회사 명'
+  );
   useEffect(() => {
     const token = localStorage.getItem('auth_token');
     if (!token) {
@@ -19,6 +20,7 @@ export default function Layout() {
       try {
         const result = await getCompanyInformation();
         setCompanyName(result?.companyName);
+        localStorage.setItem('companyName', result?.companyName);
       } catch (err) {
         console.error('회사 정보 불러오기 실패:', err.message);
         setCompanyName('');

--- a/src/pages/Onboarding.jsx
+++ b/src/pages/Onboarding.jsx
@@ -2,9 +2,9 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Carousel } from '@/components/ui/carousel';
 import { loginApi } from '@/api/authApi';
+import { getCompanyInformation } from '@/api/companyApi';
 import CustomAuthInput from '@/components/CustomAuthInput';
 import Button from '@/components/Button';
-
 export default function AuthOnboarding() {
   const [id, setId] = useState('');
   const [password, setPassword] = useState('');
@@ -22,7 +22,16 @@ export default function AuthOnboarding() {
         const { token } = response;
         localStorage.setItem('auth_token', token);
         localStorage.setItem('id', id);
-        window.location.href = '/';
+        try {
+          const companyInfo = await getCompanyInformation();
+          if (companyInfo?.companyName) {
+            localStorage.setItem('companyName', companyInfo.companyName);
+          }
+        } catch (error) {
+          console.error('회사 정보 불러오기 실패', error);
+        }
+
+        navigate('/dashboard');
       }
     } catch (err) {
       console.error('로그인 오류:', err);

--- a/src/utils/mappingUtils.js
+++ b/src/utils/mappingUtils.js
@@ -1,0 +1,59 @@
+import { fetchDriversByDeviceUid } from '@/api/driverApi';
+import apiClient from '@/api/apiClient';
+
+export async function recoverMappingsIfEmpty(
+  driverIndexMapRef,
+  deviceUidMapRef
+) {
+  const isDriverIndexMapEmpty =
+    !driverIndexMapRef.current ||
+    Object.keys(driverIndexMapRef.current).length === 0;
+  const isDeviceUidMapEmpty =
+    !deviceUidMapRef.current ||
+    Object.keys(deviceUidMapRef.current).length === 0;
+
+  if (!isDriverIndexMapEmpty || !isDeviceUidMapEmpty) {
+    console.log('매핑 정보가 이미 존재합니다. 복구 불필요');
+    return;
+  }
+
+  try {
+    console.log('매핑 정보 비어있음. 백엔드에서 정보 가져오는 중...');
+
+    // deviceUidMap 복구
+    const vehiclesResponse = await apiClient.get('/vehicles', {
+      params: { pageSize: 1000, pageIdx: 0 },
+    });
+    const vehicles = vehiclesResponse.data.data;
+    vehicles.forEach((v) => {
+      deviceUidMapRef.current[v.vehicleNumber] = v.deviceUid;
+    });
+
+    // driverIndexMap 복구
+    for (const [vehicleNumber, deviceUid] of Object.entries(
+      deviceUidMapRef.current
+    )) {
+      const driverList = await fetchDriversByDeviceUid(deviceUid, 100, 0);
+      if (driverList && driverList.length > 0) {
+        driverList.sort(
+          (a, b) => new Date(a.startTime) - new Date(b.startTime)
+        );
+        const hashToIndex = {};
+        driverList.forEach((driver, idx) => {
+          hashToIndex[driver.driverHash] = idx;
+        });
+        driverIndexMapRef.current[deviceUid] = {
+          vehicleNumber,
+          hashToIndex,
+        };
+      }
+    }
+
+    console.log('매핑 정보 복구 완료:', {
+      deviceUidMap: deviceUidMapRef.current,
+      driverIndexMap: driverIndexMapRef.current,
+    });
+  } catch (error) {
+    console.error('매핑 정보 복구 실패:', error);
+  }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
저장한 매핑 정보를 백엔드를 기반으로 불러와 매핑 정보를 유지하였습니다.
대시보드 화면의 날짜 오류를 수정하였습니다.
현재 대시보드에서 새로 고침 해야 정보가 반영되므로, 이 점은 추후 수정하겠습니다.
### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 매핑 데이터가 비어 있을 경우 자동으로 복구하는 기능이 추가되었습니다.
- **버그 수정**
	- 최근 졸음 데이터 표의 날짜 표시 방식이 개선되었습니다.
- **개선 사항**
	- 회원가입 페이지가 레이아웃에서 분리되어 별도의 경로로 이동되었습니다.
	- 로그인 후 회사 정보가 자동으로 조회 및 저장되며, 대시보드로 이동합니다.
	- 회사명이 로컬 스토리지에 저장되어 세션 간에 유지됩니다.
- **기타**
	- 불필요한 주석 및 코드가 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->