### PR TITLE
fix[#27]: 운전자 선택, 대시보드 차량 조회, 회원가입 오류 수정

### DIFF
--- a/src/components/SearchControls.jsx
+++ b/src/components/SearchControls.jsx
@@ -41,9 +41,10 @@ export default function SearchControls({
             id="driverIndex"
             name="driverIndex"
             value={selectedDriverIndex ?? ''}
-            onChange={(e) =>
-              setSelectedDriverIndex(Number(e.target.value) || null)
-            }
+            onChange={(e) => {
+              const value = e.target.value;
+              setSelectedDriverIndex(value === '' ? null : Number(value));
+            }}
             className="border-cornflower-400 text-cornflower-950 focus:border-cornflower-500 font-pretendard min-h-[53px] w-full rounded-xl border bg-white pr-10 pl-4 text-[18px] leading-[53px] font-normal transition focus:outline-none"
           >
             <option value="">전체</option>

--- a/src/pages/Dashboard/Dashboard.jsx
+++ b/src/pages/Dashboard/Dashboard.jsx
@@ -72,6 +72,10 @@ export default function Dashboard() {
     try {
       const countData = await getVehicleCount();
       const total = countData.totalVehicles;
+      if (total === 0) {
+        setRecentVehicles([]);
+        return;
+      }
       const allVehicles = await getVehicles(total, 0);
       const sorted = allVehicles
         .sort((a, b) => new Date(b.createdDate) - new Date(a.createdDate))

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -129,7 +129,7 @@ export default function SignUp() {
                 label="사업자 등록 번호"
                 name="businessNumber"
                 type="text"
-                placeholder="-없이 13자리 숫자"
+                placeholder="-없이 10자리 숫자"
                 value={formData.businessNumber}
                 onChange={handleChange}
                 required


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#27 
> ex) #이슈번호, #이슈번호

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- [x] 운전자 1 선택이 안되는 오류 수정
- [x] 자동차가 등록되지 않은 경우 대시보드에서 차량 조회 실패 오류 수정
- [x] 회원가입 화면에서 사업자 등록번호 placeholder 13자리에서 10자리로 수정

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 드라이버 선택 시 빈 값이 선택되면 올바르게 처리되도록 개선되었습니다.
  - 차량이 없을 때 불필요한 API 호출이 발생하지 않도록 대시보드의 최근 차량 조회 로직이 개선되었습니다.
- **스타일**
  - 회원가입 페이지의 사업자 등록번호 입력란 안내 문구가 13자리에서 10자리로 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->